### PR TITLE
Fix TruffleHog commit range to avoid base/head same

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,8 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: main
-        head: HEAD
+        base: ${{ github.event.pull_request.base.sha || github.event.before }}
+        head: ${{ github.event.pull_request.head.sha || github.sha }}
 
   # Job para SonarCloud analysis
   sonarcloud:


### PR DESCRIPTION
## Summary
- ensure TruffleHog uses commit SHAs for base and head so pushes to main are scanned without errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a200c043d4832fb1df4e0c7710a339